### PR TITLE
Add HDF5.jl to list of known preferences

### DIFF
--- a/KNOWN_PREFERENCES.md
+++ b/KNOWN_PREFERENCES.md
@@ -84,6 +84,9 @@ It's not used for anything right now other than to inform design.
   - `color :: Dict`
 - `Gtk4`
   - `uv_loop_integration :: String` (`auto`, `enabled` or `disabled`)
+- `HDF5`
+  - `libhdf5 :: String`
+  - `libhdf5_hl :: String`
 - `JLLPrefixes`
   - `clone_dir :: String`
 - `JuMP`


### PR DESCRIPTION
With HDF5.jl v0.17 HDF5.jl supports the preferences `libhdf5` and `libhdf5_hl`. I added them to the list of known preferences.