### PR TITLE
add get_all_prefs convenience function

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,17 @@ Example
   one: [1]
 You may need to restart Julia for preferences to take effect.
 ```
+
+### Manually Loading Preferences with `PreferenceTools.get_all`
+Some packages may not yet support Preferences.jl. As a convenience, `get_all` can be used
+to easily load preferences manually. Providing a `Dict{Symbol, Any}` type argument to
+`get_all` will provide a splat-able preferences dictionary (ie one with `Symbol` instead
+of String values). Setting `allow_symbols` will also convert symbol values stored as strings
+(e.g. ":sym") to `Symbol`s (:sym).
+
+For example, for loading preferences for PlotThemes and Plots:
+```julia
+julia> import PreferenceTools: get_all
+julia> Plots.theme(get_all(Dict{Symbol, Any}, "PlotThemes"; allow_symbols=true)[:theme])
+julia> Plots.default(;get_all(Dict{Symbol, Any}, "Plots"; allow_symbols=true)...)
+```

--- a/src/PreferenceTools.jl
+++ b/src/PreferenceTools.jl
@@ -83,6 +83,28 @@ function get_all(pkg::String; kw...)
     Base.get(Dict{String,Any}, get_all(; kw...), pkg)
 end
 
+"""
+Return a dict with:
+* string keys in `d` converted to `Symbol` keys
+* if allow_symbols: string values starting with ':' casted to `Symbol` values, e.g. ":sym" -> :sym
+"""
+function str2sym(d::AbstractDict{<:AbstractString, <:Any}; allow_symbols=false)
+    dd = Dict{Symbol, Any}(Symbol(k) => v for (k, v) in d) 
+    if allow_symbols
+        for k in findall(v->v isa AbstractString && startswith(v, ':'), dd)
+            dd[k] = Symbol(dd[k][2:end])
+        end
+    end
+    dd
+end
+
+"""
+Useful for manually setting preferences when `pkg` does not support Preferences.jl yet.
+"""
+function get_all(::Type{Dict{Symbol,Any}}, pkg::AbstractString; allow_symbols=false, kw...)
+    str2sym(get_all(pkg; kw...); allow_symbols=allow_symbols)
+end
+
 function _status(io::IO, name, prefs)
     printstyled(io, name, bold=true)
     println(io)


### PR DESCRIPTION
The current `get_all` does not convert keys to symbols and symbol values stored as strings to actual symbols. As a result, the dictionary returned is not splattable and often not usable in manually setting preferences.

`get_all_prefs` provides a simple way to set preferences when a package does not support Preferences.jl yet, for example:
```
julia> Plots.theme(PreferenceTools.get_all_prefs("PlotThemes")[:theme])
julia> Plots.default(;PreferenceTools.get_all_prefs("Plots")...)
```
